### PR TITLE
Adding encryption and publish permission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+localtest/*
 notes.txt
 .idea
 .*.sw?

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "aws_sns_topic" "topic" {
 # publish permissions.
 
 resource "aws_kms_key" "sns" {
-  count       = var.create_kms_key ? 1 : 0
+  count       = var.kms_key_arn == null ? 1 : 0
   description = "Encrypt SNS topic CenterGaugeAlerts. Managed by Terraform."
   tags        = var.tags
   policy      = <<POLICY

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,52 @@
 resource "aws_sns_topic" "topic" {
-  display_name = var.display_name
-  name = var.name
-  fifo_topic = false
-  kms_master_key_id = var.kms_master_key_id
+  display_name      = var.display_name
+  name              = var.name
+  fifo_topic        = false
+  kms_master_key_id = aws_kms_key.sns.id
+}
+
+# Cloudwatch cannot write to an SNS topic that is encrypted with the SNS CMK.
+# https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/
+# Create a key specific to this SNS topic and grant RDS and Cloudwatch 
+# publish permissions.
+
+resource "aws_kms_key" "sns" {
+  description = "Encrypt SNS topic CenterGaugeAlerts. Managed by Terraform."
+}
+
+resource "aws_iam_role" "kms_sns_key" {
+  name               = "${var.name}Decrypt"
+  assume_role_policy = data.aws_iam_policy_document.assume_kms_sns_key.json
+}
+
+# This policy defines which AWS services can assume the role defined above. 
+data "aws_iam_policy_document" "assume_kms_sns_key" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com", "rds.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "kms_sns_key" {
+  name        = "${var.name}Decrypt"
+  description = "Encrypt SNS topic CenterGaugeAlerts. Managed by Terraform."
+  policy      = data.aws_iam_policy_document.kms_sns_key.json
+}
+
+data "aws_iam_policy_document" "kms_sns_key" {
+  statement {
+    actions   = ["kms:Decrypt", "kms:GenerateDataKey"]
+    resources = [aws_kms_key.sns.arn]
+  }
+}
+
+resource "aws_iam_policy_attachment" "kms_sns_key" {
+  name       = "${var.name}Decrypt"
+  roles      = [aws_iam_role.kms_sns_key.name]
+  policy_arn = aws_iam_policy.kms_sns_key.arn
 }
 
 resource "aws_sqs_queue" "dlq" {
@@ -14,18 +58,18 @@ resource "aws_sns_topic_subscription" "subscription" {
   protocol  = "https"
   topic_arn = aws_sns_topic.topic.arn
   delivery_policy = jsonencode({
-    "healthyRetryPolicy": {
-      "numRetries": 10,
-      "numNoDelayRetries": 0,
-      "minDelayTarget": 30,
-      "maxDelayTarget": 120,
-      "numMinDelayRetries": 3,
-      "numMaxDelayRetries": 0,
-      "backoffFunction": "linear"
+    "healthyRetryPolicy" : {
+      "numRetries" : 10,
+      "numNoDelayRetries" : 0,
+      "minDelayTarget" : 30,
+      "maxDelayTarget" : 120,
+      "numMinDelayRetries" : 3,
+      "numMaxDelayRetries" : 0,
+      "backoffFunction" : "linear"
     }
   })
   redrive_policy = jsonencode({
-    "deadLetterTargetArn": aws_sqs_queue.dlq.arn
+    "deadLetterTargetArn" : aws_sqs_queue.dlq.arn
   })
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,61 @@
+data "aws_caller_identity" "current" {}
+
 resource "aws_sns_topic" "topic" {
-  display_name = var.display_name
-  name = var.name
-  fifo_topic = false
-  kms_master_key_id = var.kms_master_key_id
+  display_name      = var.display_name
+  name              = var.name
+  fifo_topic        = false
+  kms_master_key_id = aws_kms_key.sns.id
+  tags              = var.tags
+}
+
+# Cloudwatch cannot write to an SNS topic that is encrypted with the SNS CMK.
+# https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/
+# Create a key specific to this SNS topic and grant RDS and Cloudwatch 
+# publish permissions.
+
+resource "aws_kms_key" "sns" {
+  description = "Encrypt SNS topic CenterGaugeAlerts. Managed by Terraform."
+  tags        = var.tags
+  policy      = <<POLICY
+  {
+    "Version": "2012-10-17",
+    "Id": "key-default-1",
+    "Statement": [
+        {
+            "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow_CloudWatch_for_CMK",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": [ "cloudwatch.amazonaws.com", "rds.amazonaws.com", "events.amazonaws.com" ]
+            },
+            "Action": [
+                "kms:Decrypt",
+                "kms:GenerateDataKey*"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+POLICY
+}
+
+# Create the alias. Without the alias, there is no friendly name in the console
+resource "aws_kms_alias" "sns" {
+  name          = "alias/${var.name}"
+  target_key_id = aws_kms_key.sns.key_id
 }
 
 resource "aws_sqs_queue" "dlq" {
-  name = "${var.name}DeadLeterQueue"
+  name = "${var.name}DeadLetterQueue"
+  tags = var.tags
 }
 
 resource "aws_sns_topic_subscription" "subscription" {
@@ -14,18 +63,18 @@ resource "aws_sns_topic_subscription" "subscription" {
   protocol  = "https"
   topic_arn = aws_sns_topic.topic.arn
   delivery_policy = jsonencode({
-    "healthyRetryPolicy": {
-      "numRetries": 10,
-      "numNoDelayRetries": 0,
-      "minDelayTarget": 30,
-      "maxDelayTarget": 120,
-      "numMinDelayRetries": 3,
-      "numMaxDelayRetries": 0,
-      "backoffFunction": "linear"
+    "healthyRetryPolicy" : {
+      "numRetries" : 10,
+      "numNoDelayRetries" : 0,
+      "minDelayTarget" : 30,
+      "maxDelayTarget" : 120,
+      "numMinDelayRetries" : 3,
+      "numMaxDelayRetries" : 0,
+      "backoffFunction" : "linear"
     }
   })
   redrive_policy = jsonencode({
-    "deadLetterTargetArn": aws_sqs_queue.dlq.arn
+    "deadLetterTargetArn" : aws_sqs_queue.dlq.arn
   })
 }
 

--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,6 @@ POLICY
 # Create the alias. Without the alias, there is no friendly name in the console
 resource "aws_kms_alias" "sns" {
   name          = "alias/${var.name}"
-  # target_key_id = aws_kms_key.sns.key_id
   target_key_id = try(data.aws_kms_key.parameter[0].key_id, aws_kms_key.sns[0].key_id)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,3 +21,9 @@ variable "url" {
   default     = "https://alerts.centergauge.com/"
   type        = string
 }
+
+variable "kms_key" {
+  description = "Optional name of KMS key to use for encryption."
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -27,9 +27,3 @@ variable "kms_key_arn" {
   type        = string
   default     = null
 }
-
-variable "create_kms_key" {
-  description = "Whether or not to create a new KMS key."
-  type        = bool
-  default     = false
-}

--- a/variables.tf
+++ b/variables.tf
@@ -22,20 +22,14 @@ variable "url" {
   type        = string
 }
 
-<<<<<<< HEAD
-variable "kms_key" {
-  description = "Optional name of KMS key to use for encryption."
+variable "kms_key_arn" {
+  description = "Optional alias of KMS key to use for encryption."
   type        = string
   default     = null
 }
-=======
-# variable "kms_master_key_id" {
-#   description = "KMS Key to use for encryption. Cannot be CMK."
-#   default = "alias/aws/sns"
-#   type = string
-# }
 
-
-
-
->>>>>>> main
+variable "create_kms_key" {
+  description = "Whether or not to create a new KMS key."
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -16,11 +16,11 @@ variable "url" {
   type = string
 }
 
-variable "kms_master_key_id" {
-  description = "KMS Key to use for enryption"
-  default = "alias/aws/sns"
-  type = string
-}
+# variable "kms_master_key_id" {
+#   description = "KMS Key to use for encryption. Cannot be CMK."
+#   default = "alias/aws/sns"
+#   type = string
+# }
 
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,27 +1,23 @@
+
 variable "display_name" {
   description = "Overrides default display name"
-  default = "CenterGaugeAlerts"
-  type = string
+  default     = "CenterGaugeAlerts"
+  type        = string
 }
 
 variable "name" {
   description = "Overrides the default name"
-  default = "CenterGaugeAlerts"
-  type = string
+  default     = "CenterGaugeAlerts"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to be added to all resources."
+  type        = map(string)
 }
 
 variable "url" {
   description = "Overrides the default URL"
-  default = "https://alerts.centergauge.com/"
-  type = string
+  default     = "https://alerts.centergauge.com/"
+  type        = string
 }
-
-variable "kms_master_key_id" {
-  description = "KMS Key to use for enryption"
-  default = "alias/aws/sns"
-  type = string
-}
-
-
-
-


### PR DESCRIPTION
Adding KMS key to encrypt SNS topic. Granting Cloudwatch, RDS and Event Bridge Events the ability to publish to this SNS topic.